### PR TITLE
FIX: Block comments have to be the first non-space on their line

### DIFF
--- a/syntax/typoscript.vim
+++ b/syntax/typoscript.vim
@@ -6,7 +6,7 @@ endif
 setlocal isident=@,48-57,-,.,_,192-255
 
 " Top level elements
-syntax region tsComment keepend start="\/\*" end="\*\/" 
+syntax region tsComment keepend start="^\s*\/\*" end="^\s*\*\/.*$"
 syntax region tsComment keepend start="^\s*#" end="$" 
 syntax region tsComment keepend start="\v^\s*\/\/" end="$" 
 syntax region tsInclude keepend start="\v^\s*\<" end="\v\>\s*$"


### PR DESCRIPTION
Two issues were fixed to make block comments comply with https://docs.typo3.org/typo3cms/TyposcriptSyntaxReference/Syntax/TypoScriptSyntax/Index.html#syntax-comment-blocks:
- Block comment opening and closing sequence must be first non-space on it‘s line
- Any characters after the closing sequence is part of the comment, ignored by typoscript parser
